### PR TITLE
Update snyk org

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,7 +11,7 @@ jobs:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       DEBUG: true
-      ORG: guardian-mobile
+      ORG: guardian-dotcom-n2y
       SKIP_NODE: false
       
       NODE_VERSION_OVERRIDE: 16


### PR DESCRIPTION
## What does this change?

Snyk monitoring has been added to this project but the org was inadvertently set to `guardian-mobile`.

Comparing to [similar](https://github.com/guardian/interactive-atom-template-2021/blob/main/.github/workflows/snyk.yml#L14) projects we understand that the snyk org should actually be `guardian-dotcom-n2y`
